### PR TITLE
Provide the NPM version of the Lwc Dev Server package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@salesforce/lwc-dev-server)
+
 # LWC Local Development
 This repository is being used to collect feedback and issues for LWC Local Development while it is in beta. The source code for this tool will soon be open source and issues will be migrated to the main repo.
 


### PR DESCRIPTION
Provide the NPM badge on the Feedback page so customers know what the latest version is. This way they can easily manually verify they are on the latest before filing bug reports.