### PR TITLE
Add probot-stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,30 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 7
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: false
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - type:feature
+  - type:bug-p0
+  - type:bug-p1
+  - type:bug-p2
+  - type:bug-p3
+  - type:security
+  - type:feedback
+  - type:duplicate
+
+# Label to use when marking as stale
+staleLabel: type:bug-p3
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as `type:bug-p3` because it has not had
+  recent activity.
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Added probot-stale to automatically add a label to stale issues which triggers git2gus.