### PR TITLE
Replace iOS in Desktop OS section with macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
+ - OS: [e.g. macOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 


### PR DESCRIPTION
iOS in the context of a desktop OS does not make sense. Hence, this PR replaces `iOS` with the more appropriate `macOS` in the `bug_report` issue template.